### PR TITLE
PyCharm colors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'io.acari'
-version '6.0.1'
+version '6.0.2'
 
 repositories {
     maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }

--- a/changelog/CHANGELOG.html
+++ b/changelog/CHANGELOG.html
@@ -1,5 +1,9 @@
 <h1>Changelog</h1>
 <hr>
+<h1>6.0.2</h1>
+<ul>
+    <li>Better PyCharm color support.</li>
+</ul>
 <h1>6.0.1</h1>
 <ul>
     <li>2020 EAP Build Support<ul>

--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 ---
+# 6.0.2
+
+- Better PyCharm color support.
 
 # 6.0.1
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,12 @@
 kotlin.code.style=official
 sinceBuildVersion=193.4099
 untilBuildVersion=201.*
-#idePath=
+idePath=
 #idePath=C:\\Users\\birdm.DESKTOP-FO92PV5\\AppData\\Local\\JetBrains\\Toolbox\\apps\\IDEA-U\\ch-0\\193.6015.39
 #idePath=/home/alex/.local/share/JetBrains/Toolbox/apps/IDEA-U/ch-1/193.6015.39
 #idePath=/home/alex/.local/share/JetBrains/Toolbox/apps/PhpStorm/ch-0/193.5233.101
 #idePath=/home/alex/.local/share/JetBrains/Toolbox/apps/RubyMine/ch-0/193.5233.108
-idePath=/home/alex/.local/share/JetBrains/Toolbox/apps/PyCharm-P/ch-0/193.6015.41
+#idePath=/home/alex/.local/share/JetBrains/Toolbox/apps/PyCharm-P/ch-0/193.6015.41
 #idePath=/home/alex/.local/share/JetBrains/Toolbox/apps/Goland/ch-0/193.5233.112
 #idePath=/home/alex/.local/share/JetBrains/Toolbox/apps/CLion/ch-0/193.5233.144
 #idePath=/home/alex/.local/share/JetBrains/Toolbox/apps/WebStorm/ch-0/193.6015.20

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,12 @@
 kotlin.code.style=official
 sinceBuildVersion=193.4099
 untilBuildVersion=201.*
-idePath=
+#idePath=
 #idePath=C:\\Users\\birdm.DESKTOP-FO92PV5\\AppData\\Local\\JetBrains\\Toolbox\\apps\\IDEA-U\\ch-0\\193.6015.39
 #idePath=/home/alex/.local/share/JetBrains/Toolbox/apps/IDEA-U/ch-1/193.6015.39
 #idePath=/home/alex/.local/share/JetBrains/Toolbox/apps/PhpStorm/ch-0/193.5233.101
 #idePath=/home/alex/.local/share/JetBrains/Toolbox/apps/RubyMine/ch-0/193.5233.108
-#idePath=/home/alex/.local/share/JetBrains/Toolbox/apps/PyCharm-P/ch-0/193.5233.109
+idePath=/home/alex/.local/share/JetBrains/Toolbox/apps/PyCharm-P/ch-0/193.6015.41
 #idePath=/home/alex/.local/share/JetBrains/Toolbox/apps/Goland/ch-0/193.5233.112
 #idePath=/home/alex/.local/share/JetBrains/Toolbox/apps/CLion/ch-0/193.5233.144
 #idePath=/home/alex/.local/share/JetBrains/Toolbox/apps/WebStorm/ch-0/193.6015.20

--- a/src/main/kotlin/io/acari/doki/notification/UpdateNotification.kt
+++ b/src/main/kotlin/io/acari/doki/notification/UpdateNotification.kt
@@ -6,22 +6,14 @@ import com.intellij.openapi.project.Project
 val UPDATE_MESSAGE: String = """
       What's New?<br>
       <ul>
-      <li>Brand New Themes from various anime series!
-            <ul>
-                <li>KillLaKill</li>
-                <li>Re:Zero</li>
-                <li>KonoSuba</li>
-            </ul>
-        </li>
-        <li>Android Studio 4.0 Support</li>
-        <li>2020 EAP Support</li>
+        <li>Better Pycharm color support</li>
       </ul>
-      <br>Please see the <a href="https://github.com/cyclic-reference/ddlc-jetbrains-theme/blob/master/changelog/CHANGELOG.md">Changelog</a> for more details.
+      <br>Please see the <a href="https://github.com/cyclic-reference/doki-theme-jetbrains/blob/master/changelog/CHANGELOG.md">Changelog</a> for more details.
       <br>
       Thanks again for downloading <b>The Doki Theme</b>! •‿•<br>
 """.trimIndent()
 
-const val CURRENT_VERSION = "6.0.1"
+const val CURRENT_VERSION = "6.0.2"
 
 object UpdateNotification {
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -54,25 +54,25 @@
     <statusBarWidgetProvider implementation="io.acari.doki.ui.status.ThemeStatusBarProvider"/>
     <editorNotificationProvider implementation="io.acari.doki.internal.DokiEditorNotificationProvider"/>
     <themeMetadataProvider path="/theme-schema/DokiTheme.themeMetadata.json"/>
+    <themeProvider id="9f62362a-49e0-4b82-8f63-d1f98ae7799f" path="/doki/themes/mistress/Wyla.theme.json"/>
+    <themeProvider id="c8df9413-5d9f-4e0c-ae64-5d5c1cffe9a5" path="/doki/themes/mistress/Syrena.theme.json"/>
+    <themeProvider id="4693f34f-f400-4431-87f8-0be7fde660d9" path="/doki/themes/mistress/Neera.theme.json"/>
+    <themeProvider id="c915211e-faab-4696-8af2-230892052ba6" path="/doki/themes/mistress/Eleniel.theme.json"/>
+    <themeProvider id="436ff3a0-4072-4b38-8d6f-888b18b5d0ab" path="/doki/themes/mistress/Sanya.theme.json"/>
+    <themeProvider id="fc466b4f-8eb7-472c-8cbb-d99a09d4c469" path="/doki/themes/mistress/Cleo.theme.json"/>
+    <themeProvider id="91415015-8fe3-48eb-9951-70a5cd6cbb7f" path="/doki/themes/literature_club/Natsuki_Light.theme.json"/>
+    <themeProvider id="a7e0aa28-739a-4671-80ae-3980997e6b71" path="/doki/themes/literature_club/Natsuki_Dark.theme.json"/>
+    <themeProvider id="cecf3f92-76d4-4f14-9a9c-3d558b6b3b68" path="/doki/themes/literature_club/Yuri_Light.theme.json"/>
+    <themeProvider id="a14733d6-8e15-4e75-b6b8-509f323e5b3b" path="/doki/themes/literature_club/Yuri_Dark.theme.json"/>
+    <themeProvider id="cb8ef4b7-0844-4a04-b08b-754086598de4" path="/doki/themes/literature_club/Sayori_Light.theme.json"/>
+    <themeProvider id="b0340303-0a5a-4a20-9b9c-fc8ce9880078" path="/doki/themes/literature_club/Sayori_Dark.theme.json"/>
+    <themeProvider id="9a310731-ab2d-40f5-b502-fa5419f799a2" path="/doki/themes/literature_club/Monika_Light.theme.json"/>
+    <themeProvider id="dce48196-ff46-470c-b5f9-d1e23f4a79d3" path="/doki/themes/literature_club/Monika_Dark.theme.json"/>
     <themeProvider id="3a78b13e-dbf2-410f-bb20-12b57bff7735" path="/doki/themes/kill_la_kill/Satsuki.theme.json"/>
     <themeProvider id="19b65ec8-133c-4655-a77b-13623d8e97d3" path="/doki/themes/kill_la_kill/Ryuko.theme.json"/>
-    <themeProvider id="a7e0aa28-739a-4671-80ae-3980997e6b71" path="/doki/themes/literature_club/Natsuki_Dark.theme.json"/>
-    <themeProvider id="91415015-8fe3-48eb-9951-70a5cd6cbb7f" path="/doki/themes/literature_club/Natsuki_Light.theme.json"/>
-    <themeProvider id="a14733d6-8e15-4e75-b6b8-509f323e5b3b" path="/doki/themes/literature_club/Yuri_Dark.theme.json"/>
-    <themeProvider id="cecf3f92-76d4-4f14-9a9c-3d558b6b3b68" path="/doki/themes/literature_club/Yuri_Light.theme.json"/>
-    <themeProvider id="b0340303-0a5a-4a20-9b9c-fc8ce9880078" path="/doki/themes/literature_club/Sayori_Dark.theme.json"/>
-    <themeProvider id="cb8ef4b7-0844-4a04-b08b-754086598de4" path="/doki/themes/literature_club/Sayori_Light.theme.json"/>
-    <themeProvider id="dce48196-ff46-470c-b5f9-d1e23f4a79d3" path="/doki/themes/literature_club/Monika_Dark.theme.json"/>
-    <themeProvider id="9a310731-ab2d-40f5-b502-fa5419f799a2" path="/doki/themes/literature_club/Monika_Light.theme.json"/>
     <themeProvider id="63fe4617-4cac-47a5-9b93-6794514c35ad" path="/doki/themes/konosuba/Megumin.theme.json"/>
-    <themeProvider id="4693f34f-f400-4431-87f8-0be7fde660d9" path="/doki/themes/mistress/Neera.theme.json"/>
-    <themeProvider id="9f62362a-49e0-4b82-8f63-d1f98ae7799f" path="/doki/themes/mistress/Wyla.theme.json"/>
-    <themeProvider id="fc466b4f-8eb7-472c-8cbb-d99a09d4c469" path="/doki/themes/mistress/Cleo.theme.json"/>
-    <themeProvider id="c8df9413-5d9f-4e0c-ae64-5d5c1cffe9a5" path="/doki/themes/mistress/Syrena.theme.json"/>
-    <themeProvider id="436ff3a0-4072-4b38-8d6f-888b18b5d0ab" path="/doki/themes/mistress/Sanya.theme.json"/>
-    <themeProvider id="c915211e-faab-4696-8af2-230892052ba6" path="/doki/themes/mistress/Eleniel.theme.json"/>
-    <themeProvider id="f770dcfc-f41e-4b49-aa17-66e9ffc208fd" path="/doki/themes/re_zero/Rem.theme.json"/>
     <themeProvider id="35422aa4-1396-4e76-8ec6-c5560884df22" path="/doki/themes/re_zero/Beatrice.theme.json"/>
+    <themeProvider id="f770dcfc-f41e-4b49-aa17-66e9ffc208fd" path="/doki/themes/re_zero/Rem.theme.json"/>
     <themeProvider id="ecb74f1c-8c84-40c4-916f-601039ba2af0" path="/doki/themes/re_zero/Ram.theme.json"/>
   </extensions>
   <extensions defaultExtensionNs="JavaScript.JsonSchema">

--- a/themes/definitions/literature/monika/dark/Monika_Dark.xml
+++ b/themes/definitions/literature/monika/dark/Monika_Dark.xml
@@ -1914,6 +1914,16 @@
                 <option name="FOREGROUND" value="b0dd3e" />
             </value>
         </option>
+        <option name="PY.KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="3eae5d"/>
+            </value>
+        </option>
+        <option name="PY.STRING.B">
+            <value>
+                <option name="FOREGROUND" value="f1fa8c"/>
+            </value>
+        </option>
         <option name="PY.KEYWORD_ARGUMENT">
             <value>
                 <option name="FOREGROUND" value="ffb86c" />

--- a/themes/definitions/literature/natsuki/dark/Natsuki_Dark.xml
+++ b/themes/definitions/literature/natsuki/dark/Natsuki_Dark.xml
@@ -1998,8 +1998,16 @@
                 <option name="FOREGROUND" value="FF9CD6"/>
             </value>
         </option>
-        <option name="PY.KEYWORD" baseAttributes="DEFAULT_KEYWORD"/>
-        <option name="PY.KEYWORD_ARGUMENT" baseAttributes="DEFAULT_PARAMETER"/>
+        <option name="PY.KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="bca3aa"/>
+            </value>
+        </option>
+        <option name="PY.STRING.B">
+            <value>
+                <option name="FOREGROUND" value="f1fa8c"/>
+            </value>
+        </option>
         <option name="PY.PREDEFINED_DEFINITION">
             <value>
                 <option name="FOREGROUND" value="86DBFD"/>

--- a/themes/definitions/literature/sayori/dark/Sayori_Dark.xml
+++ b/themes/definitions/literature/sayori/dark/Sayori_Dark.xml
@@ -1993,8 +1993,16 @@
                 <option name="FOREGROUND" value="c1ff10"/>
             </value>
         </option>
-        <option name="PY.KEYWORD" baseAttributes="DEFAULT_KEYWORD"/>
-        <option name="PY.KEYWORD_ARGUMENT" baseAttributes="DEFAULT_PARAMETER"/>
+        <option name="PY.KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="bca3aa"/>
+            </value>
+        </option>
+        <option name="PY.STRING.B">
+            <value>
+                <option name="FOREGROUND" value="f1fa8c"/>
+            </value>
+        </option>
         <option name="PY.PREDEFINED_DEFINITION">
             <value>
                 <option name="FOREGROUND" value="86DBFD"/>

--- a/themes/definitions/literature/yuri/dark/Yuri_Dark.xml
+++ b/themes/definitions/literature/yuri/dark/Yuri_Dark.xml
@@ -1992,8 +1992,16 @@
                 <option name="FOREGROUND" value="FF9CD6"/>
             </value>
         </option>
-        <option name="PY.KEYWORD" baseAttributes="DEFAULT_KEYWORD"/>
-        <option name="PY.KEYWORD_ARGUMENT" baseAttributes="DEFAULT_PARAMETER"/>
+        <option name="PY.KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="bca3aa"/>
+            </value>
+        </option>
+        <option name="PY.STRING.B">
+            <value>
+                <option name="FOREGROUND" value="f1fa8c"/>
+            </value>
+        </option>
         <option name="PY.PREDEFINED_DEFINITION">
             <value>
                 <option name="FOREGROUND" value="86DBFD"/>

--- a/themes/definitions/mistress/eleniel/Eleniel.xml
+++ b/themes/definitions/mistress/eleniel/Eleniel.xml
@@ -1996,8 +1996,22 @@
                 <option name="FOREGROUND" value="AA9BEF"/>
             </value>
         </option>
-        <option name="PY.KEYWORD" baseAttributes="DEFAULT_KEYWORD"/>
-        <option name="PY.KEYWORD_ARGUMENT" baseAttributes="DEFAULT_PARAMETER"/>
+        <option name="PY.KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="bca3aa"/>
+            </value>
+        </option>
+        <option name="PY.KEYWORD_ARGUMENT">
+            <value>
+                <option name="FOREGROUND" value="ffb86c"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="PY.STRING.B">
+            <value>
+                <option name="FOREGROUND" value="f1fa8c"/>
+            </value>
+        </option>
         <option name="PY.PREDEFINED_DEFINITION">
             <value>
                 <option name="FOREGROUND" value="bd93f9"/>

--- a/themes/definitions/mistress/sanya/Sanya.xml
+++ b/themes/definitions/mistress/sanya/Sanya.xml
@@ -1994,8 +1994,22 @@
                 <option name="FOREGROUND" value="c1ff10"/>
             </value>
         </option>
-        <option name="PY.KEYWORD" baseAttributes="DEFAULT_KEYWORD"/>
-        <option name="PY.KEYWORD_ARGUMENT" baseAttributes="DEFAULT_PARAMETER"/>
+        <option name="PY.KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="BD84DD"/>
+            </value>
+        </option>
+        <option name="PY.KEYWORD_ARGUMENT">
+            <value>
+                <option name="FOREGROUND" value="ffb86c"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="PY.STRING.B">
+            <value>
+                <option name="FOREGROUND" value="f1fa8c"/>
+            </value>
+        </option>
         <option name="PY.PREDEFINED_DEFINITION">
             <value>
                 <option name="FOREGROUND" value="86DBFD"/>
@@ -2012,7 +2026,6 @@
                 <option name="FONT_TYPE" value="2"/>
             </value>
         </option>
-        <option name="PY.STRING.B" baseAttributes="DEFAULT_STRING"/>
         <option name="RDOC_DIRECTIVE">
             <value>
                 <option name="FOREGROUND" value="c1ff10"/>

--- a/themes/definitions/mistress/syrena/Syrena.xml
+++ b/themes/definitions/mistress/syrena/Syrena.xml
@@ -2656,6 +2656,22 @@
                 <option name="FOREGROUND" value="219598"/>
             </value>
         </option>
+        <option name="PY.KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="F59762"/>
+            </value>
+        </option>
+        <option name="PY.KEYWORD_ARGUMENT">
+            <value>
+                <option name="FOREGROUND" value="44b3d4"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="PY.STRING.B">
+            <value>
+                <option name="FOREGROUND" value="ffd866"/>
+            </value>
+        </option>
         <option name="PY.BUILTIN_NAME">
             <value>
                 <option name="FOREGROUND" value="E85160"/>

--- a/themes/definitions/mistress/wyla/Wyla.xml
+++ b/themes/definitions/mistress/wyla/Wyla.xml
@@ -2667,8 +2667,22 @@
                 <option name="FOREGROUND" value="dae838"/>
             </value>
         </option>
-        <option name="PY.KEYWORD" baseAttributes="DEFAULT_KEYWORD"/>
-        <option name="PY.KEYWORD_ARGUMENT" baseAttributes="DEFAULT_PARAMETER"/>
+        <option name="PY.KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="a28a92"/>
+            </value>
+        </option>
+        <option name="PY.KEYWORD_ARGUMENT">
+            <value>
+                <option name="FOREGROUND" value="f59762"/>
+                <option name="FONT_TYPE" value="2"/>
+            </value>
+        </option>
+        <option name="PY.STRING.B">
+            <value>
+                <option name="FOREGROUND" value="dae838"/>
+            </value>
+        </option>
         <option name="PY.PREDEFINED_DEFINITION">
             <value>
                 <option name="FOREGROUND" value="8be9fd"/>
@@ -2687,7 +2701,6 @@
                 <option name="FOREGROUND" value="dae838"/>
             </value>
         </option>
-        <option name="PY.STRING.B" baseAttributes="DEFAULT_STRING"/>
         <option name="RDOC_DIRECTIVE">
             <value>
                 <option name="FOREGROUND" value="dae838"/>

--- a/themes/templates/dark.scheme.template.xml
+++ b/themes/templates/dark.scheme.template.xml
@@ -1931,6 +1931,11 @@
                 <option name="FOREGROUND" value="$classNameColor$" />
             </value>
         </option>
+        <option name="PY.KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="$keywordColor$" />
+            </value>
+        </option>
         <option name="PY.KEYWORD_ARGUMENT">
             <value>
                 <option name="FOREGROUND" value="$stringColor$" />
@@ -1950,6 +1955,11 @@
             <value>
                 <option name="FOREGROUND" value="86dbfd" />
                 <option name="FONT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="PY.STRING.B">
+            <value>
+                <option name="FOREGROUND" value="$stringColor$" />
             </value>
         </option>
         <option name="RDOC_DIRECTIVE">

--- a/themes/templates/light.scheme.template.xml
+++ b/themes/templates/light.scheme.template.xml
@@ -1966,6 +1966,11 @@
                 <option name="FOREGROUND" value="$classNameColor$" />
             </value>
         </option>
+        <option name="PY.KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="$htmlTagColor$" />
+            </value>
+        </option>
         <option name="PY.KEYWORD_ARGUMENT">
             <value>
                 <option name="FOREGROUND" value="$stringColor$" />
@@ -1985,6 +1990,11 @@
             <value>
                 <option name="FOREGROUND" value="4C94D6" />
                 <option name="FONT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="PY.STRING.B">
+            <value>
+                <option name="FOREGROUND" value="$stringColor$" />
             </value>
         </option>
         <option name="RDOC_DIRECTIVE">

--- a/themes/templates/light.v2.scheme.template.xml
+++ b/themes/templates/light.v2.scheme.template.xml
@@ -21,6 +21,11 @@
                 <option name="FOREGROUND" value="$keywordColor$" />
             </value>
         </option>
+        <option name="PY.KEYWORD">
+            <value>
+                <option name="FOREGROUND" value="$keywordColor$" />
+            </value>
+        </option>
         <option name="RDOC_KEYWORD">
             <value>
                 <option name="FOREGROUND" value="$keywordColor$" />


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
For Some reason, PyCharm ignores the smart way to re-use colors using the base attributes.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
#198 

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- See how your change affects other areas of the code, etc. -->
```
PyCharm 2020.1 EAP (Professional Edition)
Build #PY-201.3803.74, built on January 24, 2020
PyCharm EAP User
Expiration date: February 23, 2020
Runtime version: 11.0.5+9-b674.2 amd64
VM: OpenJDK 64-Bit Server VM by JetBrains s.r.o
Linux 4.15.0-74-generic
GC: ParNew, ConcurrentMarkSweep
Memory: 1979M
Cores: 12
Registry: 
Non-Bundled Plugins: com.markskelton.one-dark-theme, io.acari.DDLCTheme
```

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project (`lint` passes clean).
- [ ] I wrote tests for added functionality.
- [X] I updated the version.
- [X] I updated the changelog with the new functionality.